### PR TITLE
Add check for numerical value before incrementing it.

### DIFF
--- a/src/commands/seedGeoFile.php
+++ b/src/commands/seedGeoFile.php
@@ -116,7 +116,7 @@ class seedGeoFile extends Command
         $count = 0; $countOrphan = 0;
         $sql = 'SELECT MAX("right") as maxRight FROM geo';
         $result = $this->sql($sql);
-        $maxBoundary = isset($result['maxRight']) ?  $result['maxRight']+1 : 0;
+        $maxBoundary = (isset($result['maxRight']) && is_numeric($result['maxRight'])) ?  $result['maxRight']+1 : 0;
         foreach ($this->geoItems->items as $item) {
             if($item->parentId === null){
                 


### PR DESCRIPTION
Sometimes the value of $result['maxRight'] is not numeric. A check to make sure we have a number before attempting to increment it.