### PR TITLE
Alternate names and faster bulk loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ php -d memory_limit=8000M artisan geo:alternate --chunk=100000
 
 ## Filters 
 
-On the HTTP API you now have a few query options:
+On the HTTP API you now have a few query options to return alternate names:
 
 | URL Params (aplly to all routes)      | Description                            | Example                                                  |
 |---------------------------------------|----------------------------------------|----------------------------------------------------------|
@@ -247,24 +247,24 @@ On the HTTP API you now have a few query options:
 |geoalternate=true&isPreferredName=true | Returns only preferred names           | api/geo/countries?geoalternate=true&isPreferredName=true |
 |geoalternate=true&isShortName=true     | Returns only short names               | api/geo/countries?geoalternate=true&isShortName=true     |
 
-`geoalternate` is mandatory, the other options can be combined if you want. `isolanguages` accepts multiple languages separated by comma.
+`geoalternate=true` is mandatory to return alternate names, the other options can be combined if you want to filter. `isolanguages` accepts multiple languages separated by comma.
 
-The fields available on alternate names are the following:
+Results are returned in a `geoalternate` key. It's an array of object, whose fields are the following:
 
 ```
 alternateNameId   : the id of this alternate name, int
 geonameid         : geonameId referring to id in table 'geoname', int
 isolanguage       : iso 639 language code 2- or 3-characters; 4-characters 'post' for postal codes and 'iata','icao' and faac for airport codes, fr_1793 for French Revolution names,  abbr for abbreviation, link to a website (mostly to wikipedia), wkdt for the wikidataid, varchar(7)
 alternate name    : alternate name or name variant, varchar(400)
-isPreferredName   : '1', if this alternate name is an official/preferred name
-isShortName       : '1', if this is a short name like 'California' for 'State of California'
-isColloquial      : '1', if this alternate name is a colloquial or slang term. Example: 'Big Apple' for 'New York'.
-isHistoric        : '1', if this alternate name is historic and was used in the past. Example 'Bombay' for 'Mumbai'.
+isPreferredName   : '1', if this alternate name is an official/preferred name, int
+isShortName       : '1', if this is a short name like 'California' for 'State of California', int
+isColloquial      : '1', if this alternate name is a colloquial or slang term. Example: 'Big Apple' for 'New York', int
+isHistoric        : '1', if this alternate name is historic and was used in the past. Example 'Bombay' for 'Mumbai', int
 from		  : from period when the name was used
 to		  : to period when the name was used
 ```
 
-Avoid getting all the geoalternatenames without extra filters, as it can be a lot of data.
+Avoid getting all the geoalternate names without extra filters, as it can be a lot of data.
 
 # Vue Component
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Geo::getByIds([390903,3175395]);   // Get a Collection of items by Ids
 ```php
 $children    = $geo->getChildren();    // Get direct Children of $geo (Collection)
 $parent      = $geo->getParent();      // Get single Parent of $geo (Geo)
-$ancenstors  = $geo->getAncensors();   // Get Ancenstors tree of $geo from top->bottom (Collection)
+$ancestors  = $geo->getAncestors();   // Get Ancestors tree of $geo from top->bottom (Collection)
 $descendants = $geo->getDescendants(); // Get all Descentants of $geo alphabetic (Collection)
 ```
 
@@ -150,7 +150,7 @@ $descendants = $geo->getDescendants(); // Get all Descentants of $geo alphabetic
 ```php
 $geo1->isParentOf($geo2);       // (Bool) Check if $geo2 is direct Parent of $geo1
 $geo2->isChildOf($geo1);        // (Bool) Check if $geo2 is direct Child of $geo1
-$geo1->isAncenstorOf($geo2);    // (Bool) Check if $geo2 is Ancenstor of $geo1
+$geo1->isAncestorOf($geo2);    // (Bool) Check if $geo2 is Ancestor of $geo1
 $geo2->isDescendantOf($geo1);   // (Bool) Check if $geo2 is Descentant of $geo1
 ```
 
@@ -163,7 +163,7 @@ Geo::capital();         // (Shortcut) Items that are capitals
 Geo::search($name);     // Items that conain $name in name OR alternames (Case InSensitive)
 Geo::areDescentants($geo);   // Items that belong to $geo
 
-$geo->ancenstors();     // Items that contain $geo
+$geo->ancestors();     // Items that contain $geo
 $geo->descendants();    // Items that belong to $geo
 $geo->children();       // Items that are direct children of $geo
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,56 @@ To reduce bandwith, all Geo model attributes will be returned except from `alter
 |fields=all                         | Returns all attributes                  | api/geo/countries?fields=all    |
 
 
+# Alternate names
+
+If you need localization/internationalization you can use the alternate names table. This is not loaded by default.
+
+- Download with alternate names:
+```
+artisan geo:download --alternate
+```
+
+- Seed. Run:
+```
+artisan geo:alternateseed
+```
+
+Like before, you can increase the memory limit for the cli invocation on demand to have process the command at once.
+```
+php -d memory_limit=8000M artisan geo:alternate --chunk=100000
+```
+
+## Filters 
+
+On the HTTP API you now have a few query options:
+
+| URL Params (aplly to all routes)      | Description                            | Example                                                  |
+|---------------------------------------|----------------------------------------|----------------------------------------------------------|
+|geoalternate=true                      | Returns the alternate names            | api/geo/countries?geoalternate=true                      |
+|geoalternate=true&isolanguage=x        | Returns only English alternate names   | api/geo/countries?geoalternate=true&isolanguage=en       |
+|geoalternate=true&isPreferredName=true | Returns only preferred names           | api/geo/countries?geoalternate=true&isPreferredName=true |
+|geoalternate=true&isShortName=true     | Returns only short names               | api/geo/countries?geoalternate=true&isShortName=true     |
+
+`geoalternate` is mandatory, the other options can be combined if you want. 
+
+
+The fields available on alternate names are the following:
+
+```
+alternateNameId   : the id of this alternate name, int
+geonameid         : geonameId referring to id in table 'geoname', int
+isolanguage       : iso 639 language code 2- or 3-characters; 4-characters 'post' for postal codes and 'iata','icao' and faac for airport codes, fr_1793 for French Revolution names,  abbr for abbreviation, link to a website (mostly to wikipedia), wkdt for the wikidataid, varchar(7)
+alternate name    : alternate name or name variant, varchar(400)
+isPreferredName   : '1', if this alternate name is an official/preferred name
+isShortName       : '1', if this is a short name like 'California' for 'State of California'
+isColloquial      : '1', if this alternate name is a colloquial or slang term. Example: 'Big Apple' for 'New York'.
+isHistoric        : '1', if this alternate name is historic and was used in the past. Example 'Bombay' for 'Mumbai'.
+from		  : from period when the name was used
+to		  : to period when the name was used
+```
+
+Avoid getting all the geoalternatenames without extra filters, as it can be a lot of data.
+
 # Vue Component
 
 A [Vue component](https://github.com/igaster/laravel_cities/blob/master/vue/geo-slect.vue) is shipped with this package that plugs into the provided API and provides an interactive way to pick a location through a series of steps. Sorry, no live demo yet, just some screenshots:
@@ -283,3 +333,4 @@ The following inputs will be submited:
 	:enable-breadcrumb = "true"       <!-- Enable/Disable Breadcrumb -->
 ></geo-select>
 ```
+

--- a/README.md
+++ b/README.md
@@ -243,12 +243,11 @@ On the HTTP API you now have a few query options:
 | URL Params (aplly to all routes)      | Description                            | Example                                                  |
 |---------------------------------------|----------------------------------------|----------------------------------------------------------|
 |geoalternate=true                      | Returns the alternate names            | api/geo/countries?geoalternate=true                      |
-|geoalternate=true&isolanguage=x        | Returns only English alternate names   | api/geo/countries?geoalternate=true&isolanguage=en       |
+|geoalternate=true&isolanguage=x        | Returns only English alternate names   | api/geo/countries?geoalternate=true&isolanguage=pt,br    |
 |geoalternate=true&isPreferredName=true | Returns only preferred names           | api/geo/countries?geoalternate=true&isPreferredName=true |
 |geoalternate=true&isShortName=true     | Returns only short names               | api/geo/countries?geoalternate=true&isShortName=true     |
 
-`geoalternate` is mandatory, the other options can be combined if you want. 
-
+`geoalternate` is mandatory, the other options can be combined if you want. `isolanguages` accepts multiple languages separated by comma.
 
 The fields available on alternate names are the following:
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ artisan geo:download --alternate
 
 - Seed. Run:
 ```
-artisan geo:alternateseed
+artisan geo:alternate
 ```
 
 Like before, you can increase the memory limit for the cli invocation on demand to have process the command at once.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Geo::getByIds([390903,3175395]);   // Get a Collection of items by Ids
 $children    = $geo->getChildren();    // Get direct Children of $geo (Collection)
 $parent      = $geo->getParent();      // Get single Parent of $geo (Geo)
 $ancestors  = $geo->getAncestors();   // Get Ancestors tree of $geo from top->bottom (Collection)
-$descendants = $geo->getDescendants(); // Get all Descentants of $geo alphabetic (Collection)
+$descendants = $geo->getDescendants(); // Get all Descendants of $geo alphabetic (Collection)
 ```
 
 
@@ -151,7 +151,7 @@ $descendants = $geo->getDescendants(); // Get all Descentants of $geo alphabetic
 $geo1->isParentOf($geo2);       // (Bool) Check if $geo2 is direct Parent of $geo1
 $geo2->isChildOf($geo1);        // (Bool) Check if $geo2 is direct Child of $geo1
 $geo1->isAncestorOf($geo2);    // (Bool) Check if $geo2 is Ancestor of $geo1
-$geo2->isDescendantOf($geo1);   // (Bool) Check if $geo2 is Descentant of $geo1
+$geo2->isDescendantOf($geo1);   // (Bool) Check if $geo2 is Descendant of $geo1
 ```
 
 ## Query scopes (Use them to Build custom queries)
@@ -161,7 +161,7 @@ Geo::level($level);     // Filter by Administration level:
 Geo::country('US');     // (Shortcut) Items that belongs to country US 
 Geo::capital();         // (Shortcut) Items that are capitals
 Geo::search($name);     // Items that conain $name in name OR alternames (Case InSensitive)
-Geo::areDescentants($geo);   // Items that belong to $geo
+Geo::areDescendants($geo);   // Items that belong to $geo
 
 $geo->ancestors();     // Items that contain $geo
 $geo->descendants();    // Items that belong to $geo

--- a/src/Geo.php
+++ b/src/Geo.php
@@ -205,7 +205,7 @@ class Geo extends EloquentTreeItem
     // get Parent (Geo)
     public function getParent()
     {
-        return self::ancestors()->where('depth', $this->depth - 1)->first();
+        return self::find($this->parent_id);
     }
 
     // get all Ancnstors (Collection) ordered by level (Country -> City)

--- a/src/Geo.php
+++ b/src/Geo.php
@@ -25,6 +25,8 @@ class Geo extends EloquentTreeItem
     // Hide From JSON
     protected $hidden = ['alternames', 'left', 'right', 'depth'];
 
+    protected $alternate = null;
+
     // ----------------------------------------------
     //  Scopes
     // ----------------------------------------------
@@ -207,6 +209,16 @@ class Geo extends EloquentTreeItem
         }
 
         return $this;
+    }
+
+    public function getGeoalternateAttribute()
+    {
+        return $this->geoalternate()->get();
+    }
+
+    public function geoalternate()
+    {
+        return $this->hasMany(Geoalternate::class, 'geonameid');
     }
 
     // ----------------------------------------------

--- a/src/Geo.php
+++ b/src/Geo.php
@@ -87,12 +87,17 @@ class Geo extends EloquentTreeItem
         });
     }
 
-    public function scopeAreDescentants($query, Geo $parent)
+    public function scopeAreDescendants($query, Geo $parent)
     {
         return $query->where(function ($query) use ($parent) {
             $query->where('left', '>', $parent->left)
                 ->where('right', '<', $parent->right);
         });
+    }
+
+    public function scopeAreDescentants($query, Geo $parent)
+    {
+        return $this->scopeAreDescendants($query, $parent);
     }
 
     public static function scopeAlternatenames($query) {
@@ -133,7 +138,7 @@ class Geo extends EloquentTreeItem
         $query = self::search($name)->orderBy('name', 'ASC');
 
         if ($parent) {
-            $query->areDescentants($parent);
+            $query->areDescendants($parent);
         }
 
         return $query->get();

--- a/src/Geo.php
+++ b/src/Geo.php
@@ -54,9 +54,18 @@ class Geo extends EloquentTreeItem
         return $query->where('left', '>', $this->left)->where('right', '<', $this->right)->alternateNames();
     }
 
-    public function scopeAncenstors($query)
+    public function scopeAncestors($query)
     {
         return $query->where('left', '<', $this->left)->where('right', '>', $this->right)->alternateNames();
+    }
+    
+    /**
+     * old method with a typo, kept for backwards compatibility.
+     * @deprecated
+     */
+    public function scopeAncenstors($query)
+    {
+        return $this->scopeAncestors($query);
     }
 
     public function scopeChildren($query)
@@ -167,9 +176,18 @@ class Geo extends EloquentTreeItem
     }
 
     // is Parent of $item (any depth) ?
-    public function isAncenstorOf(Geo $item)
+    public function isAncestorOf(Geo $item)
     {
         return ($this->left < $item->left) && ($this->right > $item->right);
+    }
+
+    /**
+     * old method with a typo, kept for backwards compatibility.
+     * @deprecated 
+     */
+    public function isAncenstorOf(Geo $item)
+    {
+        return $this->isAncestorOf($item);
     }
 
     // retrieve by name
@@ -187,13 +205,22 @@ class Geo extends EloquentTreeItem
     // get Parent (Geo)
     public function getParent()
     {
-        return self::ancenstors()->where('depth', $this->depth - 1)->first();
+        return self::ancestors()->where('depth', $this->depth - 1)->first();
     }
 
     // get all Ancnstors (Collection) ordered by level (Country -> City)
+    public function getAncestors()
+    {
+        return self::ancestors()->orderBy('depth')->get();
+    }
+
+    /**
+     * old method with a typo, kept for backwards compatibility.
+     * @deprecated
+     */
     public function getAncensors()
     {
-        return self::ancenstors()->orderBy('depth')->get();
+        return $this->getAncestors();
     }
 
     // get all Descendants (Collection) Alphabetical
@@ -203,7 +230,7 @@ class Geo extends EloquentTreeItem
     }
 
     // Return only $fields as Json. null = Show all
-    public function fliterFields($fields = null)
+    public function filterFields($fields = null)
     {
         if (is_string($fields)) { // Comma Seperated List (eg Url Param)
             $fields = explode(',', $fields);
@@ -223,6 +250,15 @@ class Geo extends EloquentTreeItem
         }
 
         return $this;
+    }
+
+    /**
+     * old method with a typo, kept for backwards compatibility.
+     * @deprecated version
+     */
+    public function fliterFields($fields = null) 
+    {
+        return $this->filterFields($fields);
     }
 
     static public function filterAlternate($query, GeoalternateOptions $options) {

--- a/src/Geo.php
+++ b/src/Geo.php
@@ -211,9 +211,27 @@ class Geo extends EloquentTreeItem
         return $this;
     }
 
+    static public function filterAlternate($request, $query) {
+        if (!$request) {
+            return $query;
+        }
+        if ($request->has('isolanguage')) {
+            $query = $query->isoLanguage(
+                explode(',', $request->input('isolanguage'))
+            );
+        }
+        if ($request->has('isPreferredName')) {
+            $query = $query->isPreferredName(1);
+        }
+        if ($request->has('isShortName')) {
+            $query = $query->isShortName(1);
+        }
+        return $query;
+    }
+
     public function getGeoalternateAttribute()
     {
-        return $this->geoalternate()->get();
+        return static::filterAlternate(request(), $this->geoalternate())->get();
     }
 
     public function geoalternate()

--- a/src/GeoController.php
+++ b/src/GeoController.php
@@ -78,7 +78,7 @@ class GeoController extends Controller
     public function ancestors($id)
     {
         $current = Geo::find($id);
-        $ancestors = $current->ancenstors()->get()->sortBy('a1code')->values();
+        $ancestors = $current->ancestors()->get()->sortBy('a1code')->values();
         $ancestors->push($current);
 
         $result = collect();
@@ -114,7 +114,7 @@ class GeoController extends Controller
     public function breadcrumbs($id)
     {
         $current = Geo::find($id);
-        $ancestors = $current->ancenstors()->get();
+        $ancestors = $current->ancestors()->get();
         $ancestors->push($current);
 
         $ancestors = $this->applyFilter($ancestors);
@@ -138,13 +138,13 @@ class GeoController extends Controller
 
             $fields = $request->input('fields');
             if ($fields == 'all') {
-                $geo->fliterFields();
+                $geo->filterFields();
             } else {
                 $fields = explode(',', $fields);
                 array_walk($fields, function (&$item) {
                     $item = strtolower(trim($item));
                 });
-                $geo->fliterFields($fields);
+                $geo->filterFields($fields);
             }
         }
 

--- a/src/GeoController.php
+++ b/src/GeoController.php
@@ -119,13 +119,15 @@ class GeoController extends Controller
             $selector->with([
                 'geoalternate' => function($query) use ($request) {
                     if ($request->has('isolanguage')) {
-                        $query->where('geoalternate.isolanguage', $request->input('isolanguage'));
+                        $query = $query->isoLanguage(
+                            explode(',', $request->input('isolanguage'))
+                        );
                     }
                     if ($request->has('isPreferredName')) {
-                        $query->where('geoalternate.isPreferredName', 1);
+                        $query = $query->isPreferredName(1);
                     }
                     if ($request->has('isShortName')) {
-                        $query->where('geoalternate.isShortName', 1);
+                        $query = $query->isShortName(1);
                     }
                 }
             ]);
@@ -165,16 +167,22 @@ class GeoController extends Controller
             }
 
             $alternate = Geoalternate::geonameid($geo->id);
-            if ($request->has('isolanguage')) {
-                $alternate = $alternate->isoLanguage($request->input('isolanguage'));
-            }
-            if ($request->has('isPreferredName')) {
-                $alternate = $alternate->isPreferredName(1);
-            }
-            if ($request->has('isShortName')) {
-                $alternate = $alternate->isShortName(1);
-            }
-            $geo->alternate = $alternate->get();
+            $alternate->with([
+                'geoalternate' => function($query) use ($request) {
+                    if ($request->has('isolanguage')) {
+                        $query = $query->isoLanguage(
+                            explode(',', $request->input('isolanguage'))
+                        );
+                    }
+                    if ($request->has('isPreferredName')) {
+                        $query = $query->isPreferredName(1);
+                    }
+                    if ($request->has('isShortName')) {
+                        $query = $query->isShortName(1);
+                    }
+                }
+            ]);
+            $geo->alternate = $alternate;
         }
 
         return $geo;

--- a/src/GeoController.php
+++ b/src/GeoController.php
@@ -118,17 +118,7 @@ class GeoController extends Controller
         if ($request->has('geoalternate')) {
             $selector->with([
                 'geoalternate' => function($query) use ($request) {
-                    if ($request->has('isolanguage')) {
-                        $query = $query->isoLanguage(
-                            explode(',', $request->input('isolanguage'))
-                        );
-                    }
-                    if ($request->has('isPreferredName')) {
-                        $query = $query->isPreferredName(1);
-                    }
-                    if ($request->has('isShortName')) {
-                        $query = $query->isShortName(1);
-                    }
+                    $query = Geo::filterAlternate($request, $query);
                 }
             ]);
         }
@@ -165,24 +155,7 @@ class GeoController extends Controller
             if (get_class($geo) == Collection::class) {
                 return $geo;
             }
-
-            $alternate = Geoalternate::geonameid($geo->id);
-            $alternate->with([
-                'geoalternate' => function($query) use ($request) {
-                    if ($request->has('isolanguage')) {
-                        $query = $query->isoLanguage(
-                            explode(',', $request->input('isolanguage'))
-                        );
-                    }
-                    if ($request->has('isPreferredName')) {
-                        $query = $query->isPreferredName(1);
-                    }
-                    if ($request->has('isShortName')) {
-                        $query = $query->isShortName(1);
-                    }
-                }
-            ]);
-            $geo->alternate = $alternate;
+            $geo->append('geoalternate');
         }
 
         return $geo;

--- a/src/GeoServiceProvider.php
+++ b/src/GeoServiceProvider.php
@@ -33,7 +33,9 @@ class GeoServiceProvider extends ServiceProvider
                 \Igaster\LaravelCities\commands\seedGeoFile::class,
                 \Igaster\LaravelCities\commands\seedJsonFile::class,
                 \Igaster\LaravelCities\commands\BuildPplTree::class,
-                \Igaster\LaravelCities\commands\Download::class,            ]);
+                \Igaster\LaravelCities\commands\Download::class,
+                \Igaster\LaravelCities\commands\seedAlternateNames::class
+            ]);
 
         }
     }

--- a/src/Geoalternate.php
+++ b/src/Geoalternate.php
@@ -30,6 +30,9 @@ class Geoalternate extends Eloquent
 
     public function scopeIsolanguage($query, $lang)
     {
+        if (is_array($lang)) {
+            return $query->whereIn('isolanguage', $lang);
+        }
         return $query->where('isolanguage', $lang);
     }
 

--- a/src/Geoalternate.php
+++ b/src/Geoalternate.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Igaster\LaravelCities;
+
+use Illuminate\Database\Eloquent\Model as Eloquent;
+use Igaster\LaravelCities\dbTree\EloquentTreeItem;
+
+class Geoalternate extends Eloquent
+{
+    protected $table = 'geoalternate';
+    
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function getGeoAttribute()
+    {
+        return $this->geo()->first();
+    }
+
+    public function geo()
+    {
+        return $this->belongsTo(Geo::class);
+    }
+
+    public function scopeGeonameid($query, $geonameid)
+    {
+        return $query->where('geonameid', $geonameid);
+    }
+
+    public function scopeIsolanguage($query, $lang)
+    {
+        return $query->where('isolanguage', $lang);
+    }
+
+    public function scopeIsPreferredName($query, $v)
+    {
+        return $query->where('isPreferredName', $v);
+    }
+
+    public function scopeIsColloquial($query, $v)
+    {
+        return $query->where('isColloquial', $v);
+    }
+
+}

--- a/src/GeoalternateOptions.php
+++ b/src/GeoalternateOptions.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Igaster\LaravelCities;
+
+use Illuminate\Http\Request;
+
+class GeoalternateOptions
+{
+    public $alternateNames = false;
+    
+    public $isolanguage = null;
+    
+    public $isPreferredName = false;
+    
+    public $isShortName = false;
+
+    public function __construct(Request $request = null) {
+        if (!$request) { // default, nothing
+            return;
+        }
+        if ($request->has('geoalternate')) {
+            $this->alternateNames = true;
+            if ($request->has('isolanguage')) {
+                $this->isolanguage = explode(',', $request->input('isolanguage'));
+            }
+            if ($request->has('isPreferredName')) {
+                $this->isPreferredName = true;
+            }
+            if ($request->has('isShortName')) {
+                $this->isShortName = true;
+            }
+        }
+    }
+}

--- a/src/commands/Download.php
+++ b/src/commands/Download.php
@@ -8,12 +8,13 @@ class Download extends Command
 {
     public const ALL_COUNTRIES = 'all';
 
-    protected $signature = 'geo:download {--countries='.self::ALL_COUNTRIES.'}';
-    protected $description = 'Download a *.txt files from geonames.org By default it will download allcountries and hierarchy files';
+    protected $signature = 'geo:download {--countries='.self::ALL_COUNTRIES.'} {--alternate}';
+    protected $description = 'Download a *.txt files from geonames.org By default it will download allcountries and hierarchy files, but not the alternate names.';
 
     public function getFileNames() : array
     {
         $countries = $this->option('countries');
+        $alternate = $this->option('alternate');
 
         $files = ['hierarchy.zip', 'admin1CodesASCII.txt'];
 
@@ -25,6 +26,9 @@ class Download extends Command
             foreach ($countries as $country) {
                 $files[] = "$country.zip";
             }
+        }
+        if ($alternate) {
+            $files[] = "alternateNamesV2.zip";
         }
 
         return $files;

--- a/src/commands/seedAlternateNames.php
+++ b/src/commands/seedAlternateNames.php
@@ -158,7 +158,7 @@ class seedAlternateNames extends Command
         }
         
         $start = microtime(true);
-        $fileName = storage_path("geo/alternateNamesV2.crop.txt"); // TODO debug
+        $fileName = storage_path("geo/alternateNamesV2.txt");
         $isAppend = $this->option('append');
 
         $this->chunkSize = $this->option('chunk');

--- a/src/commands/seedAlternateNames.php
+++ b/src/commands/seedAlternateNames.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Igaster\LaravelCities\commands;
+
+use Exception;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use PDO;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+class seedAlternateNames extends Command
+{
+    protected $signature = 'geo:alternate {--chunk=1000} {--append}}';
+    protected $description = 'Load + Parse + Save to DB a geodata alternate names file.';
+
+    private $pdo;
+    private $driver;
+
+    private $alternateItems;
+
+    private $batch = 0;
+
+    private $chunkSize = 1000;
+
+    public function __construct()
+    {
+        parent::__construct();
+        
+        $connection = config('database.default');
+        $this->driver = strtolower(config("database.connections.{$connection}.driver"));
+
+        $this->alternateItems = [];
+    }
+
+    public function sql($sql)
+    {
+        $result = $this->pdo->query($sql);
+        if ($result === false) {
+            throw new Exception("Error in SQL : '$sql'\n" . PDO::errorInfo(), 1);
+        }
+
+        return $result->fetch();
+    }
+
+    /**
+     * Get fully qualified table name with prefix if any
+     *
+     * @return string
+     */
+    public function getFullyQualifiedTableName() : string
+    {
+        return DB::getTablePrefix() . 'geoalternate';
+    }
+
+    protected function getColumnsAsStringDelimated($delimeter = '"', bool $onlyPrefix = false)
+    {
+        $columns = [
+            'alternateNameId',
+            'geonameid',
+            'isolanguage',
+            'alternatename',
+            'isPreferredName',
+            'isShortName', 
+            'isColloquial',
+            'isHistoric',
+            'from',
+            'to'
+        ];	
+
+        $modifiedColumns = [];
+
+        foreach ($columns as $column) {
+            $modifiedColumns[] = $delimeter . $column . (($onlyPrefix) ? '' : $delimeter);
+        }
+        
+        return implode(',', $modifiedColumns);
+    }
+
+    public function getDBStatement() : array
+    {
+        $sql = "INSERT INTO {$this->getFullyQualifiedTableName()} ( {$this->getColumnsAsStringDelimated()} ) VALUES ( {$this->getColumnsAsStringDelimated(':', true)} )";
+        
+        if ($this->driver == 'mysql') {
+            $sql = "INSERT INTO {$this->getFullyQualifiedTableName()} ( {$this->getColumnsAsStringDelimated('`')} ) VALUES ( {$this->getColumnsAsStringDelimated(':', true)} )";
+        }
+
+        return [$this->pdo->prepare($sql), $sql];
+    }
+
+    public function readFile(string $fileName)
+    {
+        $this->info("Reading File '$fileName'");
+        $filesize = filesize($fileName);
+        $handle = fopen($fileName, 'r');
+        $count = 0;
+
+        $progressBar = new ProgressBar($this->output, 100);
+
+        while (($line = fgets($handle)) !== false) {
+            // ignore empty lines and comments
+            if (! $line || $line === '' || strpos($line, '#') === 0) {
+                continue;
+            }
+
+            // Convert TAB sepereted line to array
+            $data = explode("\t", $line);
+
+            // Check for errors
+            if (count($data) !== 10) {
+                dd($data[0], $data[2]);
+            }
+
+            $this->alternateItems[] = $data;
+            $count++;
+
+            $progress = ftell($handle) / $filesize * 100;
+            $progressBar->setProgress($progress);
+
+            if (count($this->alternateItems) >= $this->chunkSize) {
+                $this->processItems();
+            }
+        }
+
+        $progressBar->finish();
+
+        $this->info(" Finished Reading File. $count items loaded</info>");
+    }
+
+    public function processItems()
+    {
+        // write to persistent storage
+        $this->writeToDb();
+
+        // reset the chunk
+        $this->alternateItems = [];
+
+        $this->info(PHP_EOL . 'Processed Batch ' . $this->batch);
+        $this->batch++;
+    }
+
+    public function handle()
+    {
+        $this->pdo = DB::connection()->getPdo(PDO::FETCH_ASSOC);
+
+        if (! Schema::hasTable('geoalternate')) {
+            return;
+        }
+        
+        $start = microtime(true);
+        $fileName = storage_path("geo/alternateNamesV2.txt");
+        $isAppend = $this->option('append');
+
+        $this->chunkSize = $this->option('chunk');
+
+        $this->info("Start seeding for alternateNamesV2");
+
+        DB::beginTransaction();
+
+        // Clear Table
+        if (!$isAppend) {
+            $this->info("Truncating '{$this->getFullyQualifiedTableName()}' table...");
+            DB::table('geo')->truncate();
+        }
+
+        // Read Raw file
+        $this->readFile($fileName);
+
+        // Store Tree in DB
+        $this->writeToDb();
+        
+        //Lets get back FOREIGN_KEY_CHECKS to laravel
+        DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+        $this->info(PHP_EOL . ' Relation checks enabled');
+
+        DB::commit();
+
+        $this->info(' Done</info>');
+        $time_elapsed_secs = microtime(true) - $start;
+        $this->info("Timing: $time_elapsed_secs sec</info>");
+    }
+
+    public function writeToDb()
+    {
+        // Store Tree in DB
+        $this->info('Writing in Database</info>');
+        
+        [$stmt, $sql] = $this->getDBStatement();
+
+        $count = 0;
+        $totalCount = count($this->alternateItems);
+
+        $progressBar = new ProgressBar($this->output, 100);
+
+        foreach ($this->alternateItems as $item) {
+            $params = [
+                'alternateNameId' => $item[0],
+                'geonameid' => $item[1],
+                'isolanguage' => $item[2],
+                'alternatename' => $item[3],
+                'isPreferredName' => (int)$item[4],
+                'isShortName' => (int)$item[5],
+                'isColloquial' => (int)$item[6],
+                'isHistoric' => (int)$item[7],
+                'from' => $item[8] ? $item[8] : null,
+                'to' => $item[9] ? $item[9] : null
+            ];
+
+            if ($stmt->execute($params) === false) {
+                $error = "Error in SQL : '$sql'\n" . PDO::errorInfo() . "\nParams: \n$params";
+                throw new Exception($error, 1);
+            }
+
+            $progress = $count++ / $totalCount * 100;
+            $progressBar->setProgress($progress);
+        }
+
+        $progressBar->finish();
+    }
+}

--- a/src/commands/seedGeoFile.php
+++ b/src/commands/seedGeoFile.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Helper\ProgressBar;
 
 class seedGeoFile extends Command
 {
-    protected $signature = 'geo:seed {country?} {--append} {--chunk=1000}';
+    protected $signature = 'geo:seed {country?} {--append} {--chunk=1000} {--insertSize=1000}';
     protected $description = 'Load + Parse + Save to DB a geodata file.';
 
     private $pdo;
@@ -24,6 +24,12 @@ class seedGeoFile extends Command
     private $batch = 0;
 
     private $chunkSize = 1000;
+
+    private $insertSize = 1000;
+
+    private $columns = [
+        'id', 'parent_id', 'left', 'right', 'depth', 'name', 'alternames', 'country', 'a1code', 'level', 'population', 'lat', 'long', 'timezone',
+    ];
 
     public function __construct()
     {
@@ -78,25 +84,27 @@ class seedGeoFile extends Command
 
     protected function getColumnsAsStringDelimated($delimeter = '"', bool $onlyPrefix = false)
     {
-        $columns = [
-            'id', 'parent_id', 'left', 'right', 'depth', 'name', 'alternames', 'country', 'a1code', 'level', 'population', 'lat', 'long', 'timezone',
-        ];
-
         $modifiedColumns = [];
 
-        foreach ($columns as $column) {
+        foreach ($this->columns as $column) {
             $modifiedColumns[] = $delimeter . $column . (($onlyPrefix) ? '' : $delimeter);
         }
         
         return implode(',', $modifiedColumns);
     }
 
-    public function getDBStatement() : array
+    public function getDBStatement($totalItems) : array
     {
-        $sql = "INSERT INTO {$this->getFullyQualifiedTableName()} ( {$this->getColumnsAsStringDelimated()} ) VALUES ( {$this->getColumnsAsStringDelimated(':', true)} )";
-        
+        $strItem = "(" . implode(',', array_fill(0, count($this->columns), '?')) . ")";
+        $totalItems = implode(',', array_fill(0, $totalItems, $strItem));
+       
         if ($this->driver == 'mysql') {
-            $sql = "INSERT INTO {$this->getFullyQualifiedTableName()} ( {$this->getColumnsAsStringDelimated('`')} ) VALUES ( {$this->getColumnsAsStringDelimated(':', true)} )";
+            $sql = "INSERT INTO {$this->getFullyQualifiedTableName()} ( {$this->getColumnsAsStringDelimated('`')} ) VALUES " .
+                $totalItems;
+        }
+        else {
+            $sql = "INSERT INTO {$this->getFullyQualifiedTableName()} ( {$this->getColumnsAsStringDelimated()} ) VALUES " .
+                $totalItems;
         }
 
         return [$this->pdo->prepare($sql), $sql];
@@ -283,42 +291,75 @@ class seedGeoFile extends Command
     public function writeToDb()
     {
         // Store Tree in DB
-        $this->info('Writing in Database</info>');
+        // $this->info('Writing in Database');
         
-        [$stmt, $sql] = $this->getDBStatement();
+        [$stmt, $sql] = $this->getDBStatement($this->insertSize);
 
         $count = 0;
+
         $totalCount = count($this->geoItems->items);
 
-        $progressBar = new ProgressBar($this->output, 100);
+        // $progressBar = new ProgressBar($this->output, 100);
 
+        $batch = [];
+
+        $totalToCommit = $this->insertSize * count($this->columns);
+        
         foreach ($this->geoItems->items as $item) {
-            $params = [
-                ':id' => $item->getId(),
-                ':parent_id' => $item->parentId,
-                ':left' => $item->left,
-                ':right' => $item->right,
-                ':depth' => $item->depth,
-                ':name' => substr($item->data[2], 0, 40),
-                ':alternames' => $item->data[3],
-                ':country' => $item->data[8],
-                ':a1code' => $item->data[10],
-                ':level' => $item->data[7],
-                ':population' => $item->data[14],
-                ':lat' => $item->data[4],
-                ':long' => $item->data[5],
-                ':timezone' => $item->data[17],
-            ];
+            // $params = [
+            //     ':id' => $item->getId(),
+            //     ':parent_id' => $item->parentId,
+            //     ':left' => $item->left,
+            //     ':right' => $item->right,
+            //     ':depth' => $item->depth,
+            //     ':name' => substr($item->data[2], 0, 40),
+            //     ':alternames' => $item->data[3],
+            //     ':country' => $item->data[8],
+            //     ':a1code' => $item->data[10],
+            //     ':level' => $item->data[7],
+            //     ':population' => $item->data[14],
+            //     ':lat' => $item->data[4],
+            //     ':long' => $item->data[5],
+            //     ':timezone' => $item->data[17],
+            // ];
 
-            if ($stmt->execute($params) === false) {
-                $error = "Error in SQL : '$sql'\n" . PDO::errorInfo() . "\nParams: \n$params";
-                throw new Exception($error, 1);
+            array_push($batch,
+                $item->getId(),
+                $item->parentId,
+                $item->left,
+                $item->right,
+                $item->depth,
+                substr($item->data[2], 0, 40),
+                $item->data[3],
+                $item->data[8],
+                $item->data[10],
+                $item->data[7],
+                $item->data[14],
+                $item->data[4],
+                $item->data[5],
+                $item->data[17],
+            );
+
+            if (count($batch) >= $totalToCommit) {
+                if ($stmt->execute($batch) === false) {
+                    $error = "Error in SQL : '$sql'\n" . print_r($stmt->errorInfo(), true) . "\n";
+                    throw new Exception($error, 1);
+                }
+                $batch = [];
             }
 
             $progress = $count++ / $totalCount * 100;
-            $progressBar->setProgress($progress);
+            // $progressBar->setProgress($progress);
         }
 
-        $progressBar->finish();
+        if (count($batch)) {
+            [$stmt, $sql] = $this->getDBStatement(count($batch)/count($this->columns));
+            if ($stmt->execute($batch) === false) {
+                $error = "Error in SQL : '$sql'\n" . print_r($stmt->errorInfo(), true) . "\n";
+                throw new Exception($error, 1);
+            }
+        }
+        // $progressBar->finish();
     }
+
 }

--- a/src/migrations/2020_05_04_175512_geo_alternate.php
+++ b/src/migrations/2020_05_04_175512_geo_alternate.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Geoalternate extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('geoalternate', function (Blueprint $table) {
+            $table->unsignedInteger('alternateNameId');
+            $table->unsignedInteger('geonameid')->references('id')->on('geo');
+            $table->char('isolanguage', 7);
+            $table->text('alternatename');
+            $table->boolean('isPreferredName')->default(false);
+            $table->boolean('isShortName')->default(false);
+            $table->boolean('isColloquial')->default(false);
+            $table->boolean('isHistoric')->default(false);
+            $table->char('from', 20)->nullable();
+            $table->char('to', 20)->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('geoalternate');
+    }
+}

--- a/src/migrations/2020_05_04_175512_geo_alternate.php
+++ b/src/migrations/2020_05_04_175512_geo_alternate.php
@@ -24,6 +24,8 @@ class Geoalternate extends Migration
             $table->boolean('isHistoric')->default(false);
             $table->char('from', 20)->nullable();
             $table->char('to', 20)->nullable();
+            $table->primary('alternateNameId');
+            $table->index('geonameid');
         });
     }
 

--- a/src/routes.php
+++ b/src/routes.php
@@ -7,6 +7,8 @@ Route::group(['prefix' => 'geo'], function() {
     Route::get('search/{name}/{parent_id?}', 	'\Igaster\LaravelCities\GeoController@search');
 
     Route::get('item/{id}', 		'\Igaster\LaravelCities\GeoController@item');
+    
+    Route::get('items/{id}', 		'\Igaster\LaravelCities\GeoController@items');
 
     Route::get('children/{id}', 	'\Igaster\LaravelCities\GeoController@children');
 

--- a/tests/apiTest.php
+++ b/tests/apiTest.php
@@ -3,6 +3,7 @@
 namespace Igaster\LaravelCities\Tests;
 
 use Igaster\LaravelCities\Geo;
+use Illuminate\Support\Facades\Request;
 
 class apiTest extends abstractTest
 {
@@ -31,7 +32,7 @@ class apiTest extends abstractTest
         $request = Request::create($url, 'GET');
         $response = \App::handle($request);
         if ($response->status() !== 200) {
-            throw new Exception("API Call to [$url] returned status code " . $response->status() . "\n--------------[Output]--------------\n" . strip_tags(substr($response->getContent(), strpos($response->getContent(), '<body'))), 1);
+            throw new \Exception("API Call to [$url] returned status code " . $response->status() . "\n--------------[Output]--------------\n" . strip_tags(substr($response->getContent(), strpos($response->getContent(), '<body'))), 1);
         }
         return json_decode($response->getContent());
     }

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -62,7 +62,7 @@ class geoTest extends abstractTest
     }
 
     //-- Test: isAncestorOf() isDescendantOf()
-    public function testRelationAncestorDescentant()
+    public function testRelationAncestorDescendant()
     {
         $geo1 = Geo::findName('Ionian Islands');
         $geo2 = Geo::findName('Nomos Kerkyras');

--- a/tests/geoTest.php
+++ b/tests/geoTest.php
@@ -61,17 +61,17 @@ class geoTest extends abstractTest
         $this->assertFalse($geo1->isChildOf($geo2));
     }
 
-    //-- Test: isAncenstorOf() isDescendantOf()
-    public function testRelationAncenstorDescentant()
+    //-- Test: isAncestorOf() isDescendantOf()
+    public function testRelationAncestorDescentant()
     {
         $geo1 = Geo::findName('Ionian Islands');
         $geo2 = Geo::findName('Nomos Kerkyras');
         $geo3 = Geo::findName('Dimos Corfu');
 
-        $this->assertTrue($geo1->isAncenstorOf($geo2));
-        $this->assertTrue($geo2->isAncenstorOf($geo3));
-        $this->assertTrue($geo1->isAncenstorOf($geo3));
-        $this->assertFalse($geo2->isAncenstorOf($geo1));
+        $this->assertTrue($geo1->isAncestorOf($geo2));
+        $this->assertTrue($geo2->isAncestorOf($geo3));
+        $this->assertTrue($geo1->isAncestorOf($geo3));
+        $this->assertFalse($geo2->isAncestorOf($geo1));
 
         $this->assertTrue($geo2->isDescendantOf($geo1));
         $this->assertTrue($geo3->isDescendantOf($geo2));
@@ -79,7 +79,7 @@ class geoTest extends abstractTest
         $this->assertFalse($geo1->isDescendantOf($geo2));
     }
 
-    //-- Test: getChildren(), getParent(), getAncensors()
+    //-- Test: getChildren(), getParent(), getAncestors()
     public function testTravelTree()
     {
         $children = Geo::findName('Ionian Islands')->getChildren();
@@ -95,11 +95,11 @@ class geoTest extends abstractTest
         $parent = Geo::findName('Nomos Kerkyras')->getParent();
         $this->assertEquals('Ionian Islands', $parent->name);
 
-        $ancenstors = Geo::findName('Dimos Corfu')->getAncensors();
+        $ancestors = Geo::findName('Dimos Corfu')->getAncestors();
 
-        $this->assertEquals('Hellenic Republic', $ancenstors[0]->name);
-        $this->assertEquals('Ionian Islands', $ancenstors[1]->name);
-        $this->assertEquals('Nomos Kerkyras', $ancenstors[2]->name);
+        $this->assertEquals('Hellenic Republic', $ancestors[0]->name);
+        $this->assertEquals('Ionian Islands', $ancestors[1]->name);
+        $this->assertEquals('Nomos Kerkyras', $ancestors[2]->name);
     }
 
     //-- Test: JSON field alternames returns an Array
@@ -270,13 +270,13 @@ class geoTest extends abstractTest
             'long',
         ], $result);
 
-        $result = Geo::findName('Ionian Islands')->fliterFields(['name', 'country'])->toArray();
+        $result = Geo::findName('Ionian Islands')->filterFields(['name', 'country'])->toArray();
         $this->assertArrayHasKeysOnly([
             'name',
             'country',
         ], $result);
 
-        $result = Geo::findName('Ionian Islands')->fliterFields()->toArray();
+        $result = Geo::findName('Ionian Islands')->filterFields()->toArray();
         $this->assertArrayHasKeysOnly([
             'id',
             'parent_id',


### PR DESCRIPTION
This is PR that does two things:

1. includes the option to load the alternate names table. This is useful for localization and addresses issue #22.
2. changes the loader to bulk insert items. This makes loading data orders of magnitudes faster. I loaded the entire country DB in 847 seconds in a machine that took hours to load everything before the patch.

Sorry they were mixed, I was not planning to do the bulk insert but it was just impossible to develop and to load the alternate names without it, so it all got mixed in the end.

The alternate names db is optional and loaded by a separate artisan command. It's completely backwards compatible with previous installations. 

I added a few extra query options to the API to select specific languages, which hopefully solves the i18n problem.

I tried to add automatic tests, but I couldn't figure out how you run the test setup. I suggest you document this somewhere. So I only tested the endpoints manually, but covered (hopefully) all cases.